### PR TITLE
HF-128 [Fix] 공통으로 사용되는 Header 컴포넌트 예외 처리

### DIFF
--- a/hafit-fe/src/App.js
+++ b/hafit-fe/src/App.js
@@ -3,8 +3,13 @@ import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 
 // import './App.css';
 
+// Main Layout
+import MainLayout from "./layout/MainLayout";
+
 // 공통
-import Header from './components/Navbar';
+//------ Header 예외 처리를 위한 MainLayout을 사용함에 따라 주석 처리 ------//
+//------ 2023. 05. 19 (금) 13:04 -------------//
+// import Header from "./components/Navbar";
 import PreparingPage from "./pages/PreparingPage";
 
 // 비회원
@@ -38,38 +43,42 @@ function App() {
   return (
     <Router>
       <div>
-        <Header />
+        {/* <Header /> */}
         <Routes>
-          {/* 공통 */}
-          <Route path="/prepare" element={<PreparingPage />} />
+          {/*공통 Header를 포함하는 컴포넌트 */}
+          <Route element={<MainLayout />}>
+            {/* 공통 */}
+            <Route path="/prepare" element={<PreparingPage />} />
 
-          {/* 비회원 */}
-          <Route path="/" element={<LandingPage />} />
-          <Route path="/intro" element={<LandingPage />} />
-          <Route path="/notice" element={<NoticePage />} />
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/join" element={<JoinPage />} />
+            {/* 비회원 */}
+            <Route path="/" element={<LandingPage />} />
+            <Route path="/intro" element={<LandingPage />} />
+            <Route path="/notice" element={<NoticePage />} />
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/join" element={<JoinPage />} />
 
-          {/* 회원 */}
-          <Route path="/main" element={<LoginMain />} />
-          <Route path="/mainpage" element={<LoginMain />} />
-          <Route path="/user/info" element={<EditMyInfo />} />
+            {/* 회원 */}
+            <Route path="/main" element={<LoginMain />} />
+            <Route path="/mainpage" element={<LoginMain />} />
+            <Route path="/user/info" element={<EditMyInfo />} />
 
-          {/* 운동 */}
-          <Route path="/squat/setting" element={<SquatSetting />} />
-          <Route path="/exec/result" element={<SquatResult />} />
-          <Route path="/exec/rest" element={<RestTimerPage />} />
+            {/* 운동 */}
+            <Route path="/squat/setting" element={<SquatSetting />} />
+            <Route path="/exec/result" element={<SquatResult />} />
+            <Route path="/exec/rest" element={<RestTimerPage />} />
+            
+            {/* 테스트용 */}
+            <Route path="/test" element={<Test />} />
+            <Route path="/test2" element={<Test2 />} />
 
+            {/* 임시 사용 */}
+            <Route path="/stats" element={<ExecStatsPage />} />
+          </Route>
+
+          {/* 공통 Header를 포함하지 않는 컴포넌트 */}
           {/* 커뮤니티 */}
           {/* <Route path="/community/main" element={<ViewPostsAll />} /> */}
           <Route path="/community/*" element={<CommunityRoutes />} />
-
-          {/* 테스트용 */}
-          <Route path="/test" element={<Test />} />
-          <Route path="/test2" element={<Test2 />} />
-
-          {/* 임시 사용 */}
-          <Route path="/stats" element={<ExecStatsPage />} />
         </Routes>
       </div>
     </Router>

--- a/hafit-fe/src/layout/MainLayout.jsx
+++ b/hafit-fe/src/layout/MainLayout.jsx
@@ -1,0 +1,13 @@
+import Header from '../components/Navbar';
+import { Outlet } from 'react-router-dom';
+
+const MainLayout = () => {
+  return (
+    <>
+      <Header />
+      <Outlet />
+    </>
+  );
+};
+
+export default MainLayout;


### PR DESCRIPTION
2023/05/19 - 13:24

1. /community/* 경로에 해당하는 페이지들에서는 <Header>가 랜더링 되지 않도록 예외 처리 성공
2. MainLayout에 <Outlet /> 컴포넌트 사용 -> <Header />가 필요한 컴포넌트들은 MainLayout에 포함시켜 렌더링할 수 있도록 하였음
3. '/community/*'로 커뮤니티 관련 컴포넌트를 묶어서 관리 -> MainLayout에 포함되지 않도록 예외 처리

- #22  
- #23